### PR TITLE
Hide null transceiver frequencies

### DIFF
--- a/app/src/main/java/com/rtbishop/look4sat/ui/adapters/TransmitterAdapter.kt
+++ b/app/src/main/java/com/rtbishop/look4sat/ui/adapters/TransmitterAdapter.kt
@@ -91,8 +91,10 @@ class TransmitterAdapter : RecyclerView.Adapter<TransmitterAdapter.TransmitterHo
                         predictor.getDownlinkFreq(transmitter.downlinkHigh, Date()) / freqDivider
                     )
             } else {
-                binding.transDownlink.text = context.getString(R.string.no_downlink)
-                binding.transDownlinkDoppler.text = context.getString(R.string.no_downlink_doppler)
+                binding.transDownlink.visibility = View.GONE
+                binding.transDownlinkDoppler.visibility = View.GONE
+                binding.transImgDownlink.visibility = View.GONE
+                binding.transImgDownlinkDoppler.visibility = View.GONE
             }
 
             if (transmitter.uplinkLow != null && transmitter.uplinkHigh == null) {
@@ -116,8 +118,10 @@ class TransmitterAdapter : RecyclerView.Adapter<TransmitterAdapter.TransmitterHo
                     predictor.getUplinkFreq(transmitter.uplinkHigh, Date()) / freqDivider
                 )
             } else {
-                binding.transUplink.text = context.getString(R.string.no_uplink)
-                binding.transUplinkDoppler.text = context.getString(R.string.no_uplink_doppler)
+                binding.transUplink.visibility = View.GONE
+                binding.transUplinkDoppler.visibility = View.GONE
+                binding.transImgUplink.visibility = View.GONE
+                binding.transImgUplinkDoppler.visibility = View.GONE
             }
 
             if (transmitter.mode != null) {

--- a/app/src/main/res/layout/item_transmitter.xml
+++ b/app/src/main/res/layout/item_transmitter.xml
@@ -73,7 +73,7 @@
         <TextView
             android:id="@+id/trans_downlink_doppler"
             style="@style/CardTransText"
-            android:layout_marginTop="1dp"
+            android:layout_marginTop="2dp"
             android:text="@string/trans_down_lowHigh_doppler"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/trans_img_downlink_doppler"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -63,14 +63,9 @@
     <string name="pref_refresh_rate_input_error">Введите значение между 250мс и 10000мс</string>
     <string name="pref_compass_title">Использовать компас при отображении полярных координат</string>
 
-    <string name="pref_time_utc_key" translatable="false">timeUTC</string>
     <string name="pref_time_utc_title">Показывать время пролёта по UTC</string>
 
     <string name="no_mode">Модуляция: нет</string>
-    <string name="no_uplink">Восход: нет</string>
-    <string name="no_downlink">Нисход: нет</string>
-    <string name="no_uplink_doppler">Тек. восход: нет</string>
-    <string name="no_downlink_doppler">Тек. нисход: нет</string>
     <string name="no_trans">Не найдены трансиверы для этого спутника</string>
 
     <string name="err_no_permissions">Отсутствуют необходимые разрешения</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,10 +77,6 @@
     <string name="pref_time_utc_title">Show pass time in UTC</string>
 
     <string name="no_mode">Mode: null</string>
-    <string name="no_uplink">Uplink: null</string>
-    <string name="no_downlink">Downlink: null</string>
-    <string name="no_uplink_doppler">Curr. uplink: null</string>
-    <string name="no_downlink_doppler">Curr. downlink: null</string>
     <string name="no_trans">No transceivers found for this satellite</string>
 
     <string name="err_no_permissions">Missing permissions</string>


### PR DESCRIPTION
The `Uplink: null` and `Curr. uplink: null` lines in beacons or telemetries do not make much sense to me. This might be a matter of personal taste however, so feel free to close this PR if you hold a different opinion :-)