### PR TITLE
localize pass date and time formats for Chinese

### DIFF
--- a/core/presentation/src/main/java/com/rtbishop/look4sat/core/presentation/Components.kt
+++ b/core/presentation/src/main/java/com/rtbishop/look4sat/core/presentation/Components.kt
@@ -144,7 +144,7 @@ fun RowScope.NextPassRow(pass: OrbitalPass, modifier: Modifier = Modifier, isUtc
         if (isUtc) TimeZone.getTimeZone("UTC") else TimeZone.getDefault()
     }
     val sdfTime = remember(isUtc) {
-        SimpleDateFormat("HH:mm:ss", Locale.ENGLISH).also { it.timeZone = timeZone }
+        SimpleDateFormat("HH:mm:ss", displayLocale()).also { it.timeZone = timeZone }
     }
     ElevatedCard(
         modifier = modifier
@@ -211,6 +211,11 @@ fun RowScope.NextPassRow(pass: OrbitalPass, modifier: Modifier = Modifier, isUtc
             }
         }
     }
+}
+
+private fun displayLocale(): Locale {
+    val locale = Locale.getDefault()
+    return if (locale.language == Locale.CHINESE.language) locale else Locale.ENGLISH
 }
 
 @Composable

--- a/feature/passes/src/main/java/com/rtbishop/look4sat/feature/passes/PassesScreen.kt
+++ b/feature/passes/src/main/java/com/rtbishop/look4sat/feature/passes/PassesScreen.kt
@@ -292,6 +292,11 @@ private fun StickyDateHeader(label: String, sunriseTime: String, sunsetTime: Str
     }
 }
 
+private fun displayLocale(): Locale {
+    val locale = Locale.getDefault()
+    return if (locale.language == Locale.CHINESE.language) locale else Locale.ENGLISH
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun DeepSpacePassPreview() {
@@ -324,7 +329,7 @@ private fun PassItem(
         if (isUtc) TimeZone.getTimeZone("UTC") else TimeZone.getDefault()
     }
     val sdfTime = remember(isUtc) {
-        SimpleDateFormat("HH:mm:ss", Locale.ENGLISH).also { it.timeZone = timeZone }
+        SimpleDateFormat("HH:mm:ss", displayLocale()).also { it.timeZone = timeZone }
     }
     val aosTimeStr = remember(pass.aosTime, isUtc) { sdfTime.format(Date(pass.aosTime)) }
     val losTimeStr = remember(pass.losTime, isUtc) { sdfTime.format(Date(pass.losTime)) }

--- a/feature/passes/src/main/java/com/rtbishop/look4sat/feature/passes/PassesViewModel.kt
+++ b/feature/passes/src/main/java/com/rtbishop/look4sat/feature/passes/PassesViewModel.kt
@@ -145,12 +145,28 @@ class PassesViewModel(
         }
     }
 
+    private fun displayLocale(): Locale {
+        val locale = Locale.getDefault()
+        return if (locale.language == Locale.CHINESE.language) locale else Locale.ENGLISH
+    }
+
+    /** Returns the visible pass-date format. Keep non-Chinese locales identical to upstream. */
+    private fun dateFormat(tz: TimeZone): SimpleDateFormat {
+        val locale = displayLocale()
+        val pattern = if (locale.language == Locale.CHINESE.language) {
+            "yyyy'年'M'月'd'日' EEEE"
+        } else {
+            "EEE, dd MMM yyyy"
+        }
+        return SimpleDateFormat(pattern, locale).also { it.timeZone = tz }
+    }
+
     // Computes sunrise/sunset strings for each unique calendar day in the pass list, plus today for DeepSpace
     private fun computeSunTimes(passes: List<OrbitalPass>, isUtc: Boolean): Map<String, Pair<String, String>> {
         val stationPos = settingsRepo.stationPosition.value
         val tz = if (isUtc) TimeZone.getTimeZone("UTC") else TimeZone.getDefault()
-        val sdfDate = SimpleDateFormat("EEE, dd MMM yyyy", Locale.ENGLISH).also { it.timeZone = tz }
-        val sdfTime = SimpleDateFormat("HH:mm", Locale.ENGLISH).also { it.timeZone = tz }
+        val sdfDate = dateFormat(tz)
+        val sdfTime = SimpleDateFormat("HH:mm", displayLocale()).also { it.timeZone = tz }
         val result = LinkedHashMap<String, Pair<String, String>>()
         // DeepSpace group always shows today's sun times
         if (passes.any { it.isDeepSpace }) {
@@ -173,7 +189,7 @@ class PassesViewModel(
 
     private fun groupPasses(passes: List<OrbitalPass>, isUtc: Boolean): Map<String, List<OrbitalPass>> {
         val tz = if (isUtc) TimeZone.getTimeZone("UTC") else TimeZone.getDefault()
-        val sdfDate = SimpleDateFormat("EEE, dd MMM yyyy", Locale.ENGLISH).also { it.timeZone = tz }
+        val sdfDate = dateFormat(tz)
         val ordered = LinkedHashMap<String, List<OrbitalPass>>()
         val deepSpace = passes.filter { it.isDeepSpace }
         if (deepSpace.isNotEmpty()) ordered["DeepSpace (period >225min)"] = deepSpace


### PR DESCRIPTION
This PR localizes pass date/time display for Chinese system locales while keeping existing behavior unchanged for non-Chinese locales.

Changes:
- Use a Chinese-friendly pass date header format when the device language is Chinese:
  - `yyyy年M月d日 EEEE`
- Keep the original upstream English format for all non-Chinese locales:
  - `EEE, dd MMM yyyy`
- Apply the same locale selection to:
  - pass list date headers
  - sunrise/sunset header times
  - pass AOS/LOS times
  - the next-pass row time display
- Ensure `groupPasses()` and `computeSunTimes()` use the same date formatter, so localized date headers still match the `sunTimes` lookup keys.