### PR TITLE
fix: recalculate radar track on station position change + i18n fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ fastlane/readme.md
 /app/release/output-metadata.json
 /app/release/
 /.kotlin/sessions/
+.hermes/

--- a/core/presentation/src/main/res/values-zh/strings.xml
+++ b/core/presentation/src/main/res/values-zh/strings.xml
@@ -87,7 +87,7 @@
     <string name="prefs_updated_title">更新：%s</string>
     <string name="prefs_updated_time">yyyy MMM d - HH:mm:ss</string>
 
-    <string name="prefs_loc_title">站位</string>
+    <string name="prefs_loc_title">站点位置</string>
     <string name="prefs_loc_gps_title">GPS 定位</string>
     <string name="prefs_loc_gps_error">检查您的位置权限</string>
     <string name="prefs_loc_input_title">输入位置</string>
@@ -95,11 +95,11 @@
     <string name="prefs_loc_qth_title">QTH 网格</string>
     <string name="prefs_loc_qth_error">无效的 QTH 网格</string>
     <string name="prefs_loc_success">位置更新成功</string>
-    <string name="prefs_station_title">站位</string>
-    <string name="prefs_station_lat_text">站位纬度</string>
-    <string name="prefs_station_lon_text">站位经度</string>
+    <string name="prefs_station_title">站点位置</string>
+    <string name="prefs_station_lat_text">站点纬度</string>
+    <string name="prefs_station_lon_text">站点经度</string>
     <string name="prefs_locator_title">QTH 定位</string>
-    <string name="prefs_locator_text">通过 QTH 设置站位</string>
+    <string name="prefs_locator_text">通过 QTH 设置站点位置</string>
 
     <string name="prefs_data_title">卫星数据更新</string>
     <string name="prefs_data_entries">卫星：%s</string>

--- a/core/presentation/src/main/res/values-zh/strings.xml
+++ b/core/presentation/src/main/res/values-zh/strings.xml
@@ -155,6 +155,8 @@
     <string name="prefs_other_switch_sweep">雷达扫描动画</string>
     <string name="prefs_other_switch_sensors">传感器控制雷达</string>
     <string name="prefs_other_switch_night_mode">红色夜间模式</string>
+    <string name="prefs_other_compass_offset">雷达罗盘水平偏移量</string>
+    <string name="prefs_other_compass_offset_elev">雷达罗盘俯仰偏移量</string>
 
     <string name="prefs_highlight_title">仰角高亮</string>
     <string name="prefs_highlight_low">低 &lt; %1$d°</string>

--- a/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarViewModel.kt
+++ b/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarViewModel.kt
@@ -65,8 +65,8 @@ class RadarViewModel(
     private val showToast: IShowToast
 ) : ViewModel() {
 
-    private val stationPos = settingsRepo.stationPosition.value
-    private val magDeclination = sensorsRepo.getMagDeclination(stationPos)
+    private var stationPos = settingsRepo.stationPosition.value
+    private var magDeclination = sensorsRepo.getMagDeclination(stationPos)
     private var compassOffset = settingsRepo.otherSettings.value.radarCompassOffset
     private var compassOffsetElev = settingsRepo.otherSettings.value.radarCompassOffsetElev
     private var transponders: List<SatRadio> = emptyList()
@@ -92,6 +92,7 @@ class RadarViewModel(
 
     init {
         collectSettingsChanges()  // also handles initial sensor subscription
+        collectStationPositionChanges()
         collectPassAndStartTickLoop()
         collectRadioTrackingState()
     }
@@ -133,6 +134,23 @@ class RadarViewModel(
                 when {
                     settings.stateOfSensors -> startSensorCollection()
                     else -> stopSensorCollection()
+                }
+            }
+        }
+    }
+
+    private fun collectStationPositionChanges() {
+        viewModelScope.launch {
+            settingsRepo.stationPosition.collect { newPos ->
+                if (stationPos != newPos) {
+                    stationPos = newPos
+                    magDeclination = sensorsRepo.getMagDeclination(stationPos)
+                    lastCelestialUpdateMs = 0L // force celestial recompute on next tick
+                    val pass = _uiState.value.currentPass ?: return@collect
+                    if (!pass.isDeepSpace) {
+                        val track = satelliteRepo.getTrack(pass.orbitalObject, stationPos, pass.aosTime, pass.losTime)
+                        _uiState.update { it.copy(satTrack = track) }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Bug: Radar track not recalculated when station position changes

When the user changes their station position (by clicking on the map, entering coordinates, or updating the QTH grid), the radar track line simply translates instead of being recalculated from the new location. Restarting the app is required to see the correct track.

**Root cause:** `RadarViewModel` captures `stationPos` as a `val` at construction time and never updates it. The tick loop and track calculation both use this stale value.

**Fix:**
- Changed `stationPos` and `magDeclination` from `val` to `var`
- Added `collectStationPositionChanges()` which observes `settingsRepo.stationPosition` and:
  - Updates `stationPos` and `magDeclination`
  - Forces celestial position recompute on the next tick
  - Recalculates the satellite track (`satTrack`) with the new position

### i18n: Chinese station position text update
- Updated "站位" to "站点位置" across all Chinese (zh) strings for better readability