### PR TITLE
feat: remember per-satellite doppler offset in calculator

### DIFF
--- a/core/data/src/main/java/com/rtbishop/look4sat/core/data/repository/SettingsRepo.kt
+++ b/core/data/src/main/java/com/rtbishop/look4sat/core/data/repository/SettingsRepo.kt
@@ -37,6 +37,7 @@ import com.rtbishop.look4sat.core.domain.utility.round
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import org.json.JSONObject
 
 class SettingsRepo(
     private val locationManager: LocationManager,
@@ -417,5 +418,27 @@ class SettingsRepo(
         baudRate = preferences.getInt(keyRadioBaudRate, 4800),
         splitMode = preferences.getBoolean(keyRadioSplitMode, false)
     )
-    //endregion
+
+    private val keySatelliteOffsets = "satelliteOffsets"
+
+    override fun getSatelliteOffset(catnum: Int): String {
+        val json = preferences.getString(keySatelliteOffsets, "{}") ?: "{}"
+        return try {
+            JSONObject(json).optString(catnum.toString(), "")
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    override fun setSatelliteOffset(catnum: Int, offset: String) {
+        val json = preferences.getString(keySatelliteOffsets, "{}") ?: "{}"
+        val updated = try {
+            val obj = JSONObject(json)
+            if (offset.isEmpty()) obj.remove(catnum.toString()) else obj.put(catnum.toString(), offset)
+            obj.toString()
+        } catch (e: Exception) {
+            """{"$catnum": "$offset"}"""
+        }
+        preferences.edit { putString(keySatelliteOffsets, updated) }
+    }
 }

--- a/core/data/src/test/java/com/rtbishop/look4sat/core/data/repository/DatabaseRepoTest.kt
+++ b/core/data/src/test/java/com/rtbishop/look4sat/core/data/repository/DatabaseRepoTest.kt
@@ -213,6 +213,10 @@ private class FakeSettingsRepo(dataSources: DataSourcesSettings = defaultDataSou
     }
 
     override fun updateRadioControlSettings(settings: RadioControlSettings) = Unit
+
+    override fun getSatelliteOffset(catnum: Int): String = ""
+
+    override fun setSatelliteOffset(catnum: Int, offset: String) = Unit
 }
 
 private fun defaultDataSourcesSettings(): DataSourcesSettings {

--- a/core/data/src/test/java/com/rtbishop/look4sat/core/data/repository/SelectionRepoTest.kt
+++ b/core/data/src/test/java/com/rtbishop/look4sat/core/data/repository/SelectionRepoTest.kt
@@ -167,6 +167,10 @@ class SelectionRepoTest {
         override fun updateDataSourcesSettings(settings: DataSourcesSettings) = Unit
 
         override fun updateRadioControlSettings(settings: RadioControlSettings) = Unit
+
+        override fun getSatelliteOffset(catnum: Int): String = ""
+
+        override fun setSatelliteOffset(catnum: Int, offset: String) = Unit
     }
 }
 

--- a/core/domain/src/main/java/com/rtbishop/look4sat/core/domain/repository/ISettingsRepo.kt
+++ b/core/domain/src/main/java/com/rtbishop/look4sat/core/domain/repository/ISettingsRepo.kt
@@ -75,4 +75,9 @@ interface ISettingsRepo {
     val radioControlSettings: StateFlow<RadioControlSettings>
     fun updateRadioControlSettings(settings: RadioControlSettings)
     //endregion
+
+    //region # Per-satellite calculator offset settings
+    fun getSatelliteOffset(catnum: Int): String
+    fun setSatelliteOffset(catnum: Int, offset: String)
+    //endregion
 }

--- a/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarScreen.kt
+++ b/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarScreen.kt
@@ -198,7 +198,8 @@ private fun PagerCard(
                         transceivers = uiState.transceivers.transmitters,
                         selectedUuid = uiState.transceivers.selectedUuid,
                         orbitalPos = uiState.orbitalPos,
-                        onAction = onAction
+                        onAction = onAction,
+                        calculatorOffsetKHz = uiState.calculatorOffsetKHz
                     )
                     RadarPage.Sstv -> SstvPage(
                         sstv = uiState.sstv,

--- a/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarState.kt
+++ b/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarState.kt
@@ -63,7 +63,8 @@ data class RadarState(
     val moonPosition: CelestialComputer.MoonPosition? = null,
     val transceivers: TransceiverSubState = TransceiverSubState(),
     val radioControl: RadioControlSubState = RadioControlSubState(),
-    val sstv: SstvSubState = SstvSubState()
+    val sstv: SstvSubState = SstvSubState(),
+    val calculatorOffsetKHz: String = ""
 )
 
 enum class SstvStatus { Idle, Recording }
@@ -97,4 +98,7 @@ sealed interface RadarAction {
     data object SstvReset : RadarAction
     data class SstvSelectMode(val modeName: String) : RadarAction
     data class SstvPermissionResult(val granted: Boolean) : RadarAction
+
+    // Calculator actions
+    data class ChangeCalculatorOffset(val offsetKHz: String) : RadarAction
 }

--- a/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarViewModel.kt
+++ b/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/RadarViewModel.kt
@@ -260,7 +260,17 @@ class RadarViewModel(
                 // Compute toggle state before the update so we don't read post-update value
                 val isTogglingOff = _uiState.value.transceivers.selectedUuid == action.uuid
                 val newUuid = if (isTogglingOff) null else action.uuid
-                _uiState.update { it.copy(transceivers = it.transceivers.copy(selectedUuid = newUuid)) }
+                // Load the saved offset for the newly selected satellite
+                val offsetKHz = if (!isTogglingOff) {
+                    transponders.find { it.uuid == action.uuid }
+                        ?.catnum?.let { settingsRepo.getSatelliteOffset(it) } ?: ""
+                } else ""
+                _uiState.update {
+                    it.copy(
+                        transceivers = it.transceivers.copy(selectedUuid = newUuid),
+                        calculatorOffsetKHz = offsetKHz
+                    )
+                }
                 // Only update the tracking service when selecting a different transponder to
                 // avoid resetting a user-adjusted TX base on re-expand
                 if (!isTogglingOff) {
@@ -308,6 +318,15 @@ class RadarViewModel(
             RadarAction.SstvReset -> {
                 sstvDecoder?.clearPixels()
                 _uiState.update { it.copy(sstv = it.sstv.copy(currentFrame = null)) }
+            }
+            is RadarAction.ChangeCalculatorOffset -> {
+                val catnum = _uiState.value.transceivers.selectedUuid?.let { uuid ->
+                    transponders.find { it.uuid == uuid }?.catnum
+                }
+                if (catnum != null) {
+                    settingsRepo.setSatelliteOffset(catnum, action.offsetKHz)
+                }
+                _uiState.update { it.copy(calculatorOffsetKHz = action.offsetKHz) }
             }
         }
     }

--- a/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/TransceiversPage.kt
+++ b/feature/radar/src/main/java/com/rtbishop/look4sat/feature/radar/TransceiversPage.kt
@@ -128,6 +128,7 @@ fun CalculatorPage(
     selectedUuid: String?,
     orbitalPos: OrbitalPos?,
     onAction: (RadarAction) -> Unit,
+    calculatorOffsetKHz: String = "",
     modifier: Modifier = Modifier
 ) {
     val calculatorTransceivers = remember(transceivers) {
@@ -180,6 +181,8 @@ fun CalculatorPage(
             DopplerFrequencyCalculator(
                 transponder = selectedTransceiver,
                 orbitalPos = orbitalPos,
+                offsetKHz = calculatorOffsetKHz,
+                onOffsetChange = { onAction(RadarAction.ChangeCalculatorOffset(it)) },
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -521,6 +524,8 @@ private enum class EditedField { TX, PASSBAND, RX }
 private fun DopplerFrequencyCalculator(
     transponder: SatRadio,
     orbitalPos: OrbitalPos?,
+    offsetKHz: String = "",
+    onOffsetChange: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (orbitalPos == null || !DopplerFrequencyCalculator.isLinearTransponder(transponder)) return
@@ -529,7 +534,6 @@ private fun DopplerFrequencyCalculator(
     var txFrequencyHz by remember { mutableStateOf(0L) }
     var rxFrequencyHz by remember { mutableStateOf(0L) }
     var passbandPosition by remember { mutableStateOf(0.5f) }
-    var offsetKHz by remember { mutableStateOf("") }
     var stepSizeKHz by remember { mutableIntStateOf(1) }
 
     val offsetHz = offsetKHz.toDoubleOrNull()?.let { it * 1000 }?.toLong() ?: 0L
@@ -712,7 +716,7 @@ private fun DopplerFrequencyCalculator(
                 ) {
                     BasicTextField(
                         value = offsetKHz,
-                        onValueChange = { offsetKHz = it },
+                        onValueChange = onOffsetChange,
                         singleLine = true,
                         textStyle = TextStyle(
                             fontSize = 16.sp,


### PR DESCRIPTION
## Feature

The linear transponder frequency calculator on the Radar page has an offset (kHz) field for fine-tuning the transponder passband position. Currently it resets to empty every time the user opens the calculator for a satellite.

This PR persists the last entered offset per satellite and restores it when the calculator is shown again for that satellite.

## Implementation

Follows the project's MVI / Clean Architecture conventions (per review feedback — no data layer access from the UI):

- `ISettingsRepo`: added `getSatelliteOffset(catnum)` / `setSatelliteOffset(catnum, offset)`
- `SettingsRepo`: backed by SharedPreferences, all offsets stored as a single JSON string under key `satelliteOffsets` — avoids creating one pref entry per satellite
- `RadarState`: new `calculatorOffsetKHz` field + new `RadarAction.ChangeCalculatorOffset`
- `RadarViewModel`: loads the saved offset when a transponder is selected (`SelectTransmitter`), saves it on `ChangeCalculatorOffset`
- `CalculatorPage` / `DopplerFrequencyCalculator`: receive the offset as a parameter and dispatch changes via `onAction`, no direct SharedPreferences access in the UI layer

Data flow:
```
UI input → RadarAction.ChangeCalculatorOffset
  → ViewModel: settingsRepo.setSatelliteOffset(catnum, offset)
  → StateFlow update → UI recomposes

Satellite switch → RadarAction.SelectTransmitter
  → ViewModel: settingsRepo.getSatelliteOffset(catnum)
  → StateFlow update → UI shows saved offset
```

## Verification

- `:core:domain:test` passed
- `:core:data:compileDebugKotlin` and `:feature:radar:compileDebugKotlin` passed
- Test fakes (`FakeSettingsRepo` in two test files) updated with the new interface methods
- No new dependencies; 8 files changed (+70 / −6)