### PR TITLE
i18n: localize AMSAT status screen for Chinese

### DIFF
--- a/core/data/src/main/java/com/rtbishop/look4sat/core/data/repository/AmSatRepository.kt
+++ b/core/data/src/main/java/com/rtbishop/look4sat/core/data/repository/AmSatRepository.kt
@@ -92,11 +92,10 @@ class AmSatRepository(private val remoteSource: IRemoteSource) : IAmSatRepositor
     /** Build one SatStatus (5 days x 12 slots) per catalog satellite, slotting reports by age. */
     private fun buildStatuses(names: List<String>, reports: List<ApiReport>, nowSec: Long): List<SatStatus> {
         val byName = reports.groupBy { it.name }
-        val monthAbbr = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
         val utc = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
         val labels = (0 until 3).map { d ->
             utc.timeInMillis = (nowSec - d * 86400L) * 1000
-            "${monthAbbr[utc.get(Calendar.MONTH)]} ${utc.get(Calendar.DAY_OF_MONTH)}"
+            formatDayLabel(utc)
         }
         return names.map { name ->
             val slots = (0 until 36).map { slotIdx ->
@@ -118,6 +117,15 @@ class AmSatRepository(private val remoteSource: IRemoteSource) : IAmSatRepositor
                 SatDay(dateLabel = labels[d], slots = slots.subList(d * 12, (d + 1) * 12))
             }
             SatStatus(name = name, days = days)
+        }
+    }
+
+    private fun formatDayLabel(calendar: Calendar): String {
+        return if (Locale.getDefault().language == Locale.CHINESE.language) {
+            "${calendar.get(Calendar.MONTH) + 1}月${calendar.get(Calendar.DAY_OF_MONTH)}日"
+        } else {
+            val monthAbbr = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+            "${monthAbbr[calendar.get(Calendar.MONTH)]} ${calendar.get(Calendar.DAY_OF_MONTH)}"
         }
     }
 

--- a/core/presentation/src/main/res/values-zh/strings.xml
+++ b/core/presentation/src/main/res/values-zh/strings.xml
@@ -12,6 +12,25 @@
     <string name="nav_map">地图</string>
     <string name="nav_prefs">设置</string>
 
+    <!-- AMSAT Status screen -->
+    <string name="nav_amsat">AMSAT</string>
+    <string name="amsat_title">AMSAT 卫星状态</string>
+    <string name="amsat_refresh">刷新</string>
+    <string name="amsat_retry">重试</string>
+    <string name="amsat_updated">更新于：</string>
+    <string name="amsat_active">活跃</string>
+    <string name="amsat_tlm">遥测/信标</string>
+    <string name="amsat_not_heard">未听到</string>
+    <string name="amsat_conflict">冲突</string>
+    <string name="amsat_name">名称</string>
+    <string name="amsat_load_failed">加载失败 - 检查网络后重试</string>
+    <string name="amsat_no_reports">此时间段无报告</string>
+    <string name="amsat_close">关闭</string>
+    <string name="amsat_status_heard">已听到</string>
+    <string name="amsat_status_tlm_only">仅遥测</string>
+    <string name="amsat_status_not_heard">未听到</string>
+    <string name="amsat_status_crew_active">乘组活跃</string>
+
     <!-- Satellites screen -->
     <string name="sat_type_hint">模式：%s</string>
     <string name="sat_type_title">选择模式</string>

--- a/core/presentation/src/main/res/values/strings.xml
+++ b/core/presentation/src/main/res/values/strings.xml
@@ -79,6 +79,10 @@
     <string name="amsat_load_failed">Load failed - check network and retry</string>
     <string name="amsat_no_reports">No reports for this period</string>
     <string name="amsat_close">Close</string>
+    <string name="amsat_status_heard">Heard</string>
+    <string name="amsat_status_tlm_only">Telemetry Only</string>
+    <string name="amsat_status_not_heard">Not Heard</string>
+    <string name="amsat_status_crew_active">Crew Active</string>
 
     <!-- Radar screen -->
     <string name="radar_back">Back</string>

--- a/feature/status/src/main/java/com/rtbishop/look4sat/feature/status/SatStatusScreen.kt
+++ b/feature/status/src/main/java/com/rtbishop/look4sat/feature/status/SatStatusScreen.kt
@@ -55,6 +55,7 @@ import com.rtbishop.look4sat.core.presentation.InfoDialog
 import com.rtbishop.look4sat.core.presentation.R
 import com.rtbishop.look4sat.core.presentation.layoutPadding
 import java.util.Calendar
+import java.util.Locale
 
 /** Fixed width per day tile — tablet-safe; name column absorbs remaining space. */
 private val TILE_WIDTH: Dp = 64.dp
@@ -74,6 +75,19 @@ private fun statusColorOf(statusText: String): Color {
             Color(0xFFDC267F)
         else ->
             MaterialTheme.colorScheme.error
+    }
+}
+
+/** Localize AMSAT API status text for the current locale; falls back to the raw text. */
+@Composable
+private fun statusTextOf(statusText: String): String {
+    if (Locale.getDefault().language != Locale.CHINESE.language) return statusText
+    return when (statusText.lowercase()) {
+        "heard" -> stringResource(R.string.amsat_status_heard)
+        "telemetry only" -> stringResource(R.string.amsat_status_tlm_only)
+        "not heard" -> stringResource(R.string.amsat_status_not_heard)
+        "crew active" -> stringResource(R.string.amsat_status_crew_active)
+        else -> statusText
     }
 }
 
@@ -296,7 +310,7 @@ private fun ReportDialog(statusName: String, day: SatDay, reports: Map<String, S
                                     .background(statusColorOf(report.statusText))
                             )
                             Spacer(modifier = Modifier.width(6.dp))
-                            Text(text = report.statusText, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                            Text(text = statusTextOf(report.statusText), fontSize = 14.sp, fontWeight = FontWeight.Bold)
                         }
                         Text(
                             text = "${report.call}  ${report.dateUtc}  ${report.timeUtc}" +
@@ -318,10 +332,14 @@ private fun formatFetchedAt(utcMs: Long): String {
     val cal = Calendar.getInstance()
     cal.timeInMillis = utcMs
     val day = cal.get(Calendar.DAY_OF_MONTH)
-    val month = MONTH_ABBR[cal.get(Calendar.MONTH)]
+    val monthIndex = cal.get(Calendar.MONTH)
     val year = cal.get(Calendar.YEAR)
     val hh = cal.get(Calendar.HOUR_OF_DAY).toString().padStart(2, '0')
     val mm = cal.get(Calendar.MINUTE).toString().padStart(2, '0')
     val ss = cal.get(Calendar.SECOND).toString().padStart(2, '0')
-    return "$day$month $year - $hh:$mm:$ss"
+    return if (Locale.getDefault().language == Locale.CHINESE.language) {
+        "${year}年${monthIndex + 1}月${day}日 - $hh:$mm:$ss"
+    } else {
+        "$day${MONTH_ABBR[monthIndex]} $year - $hh:$mm:$ss"
+    }
 }


### PR DESCRIPTION
### Requirement

The AMSAT status screen shows visible English text even when the device language is Chinese: the day labels use English month abbreviations (`Sep 1`), the updated timestamp uses the English format (`1Sep 2026 - HH:mm:ss`), the legend/title/status texts fall back to English, and the AMSAT API status strings (`Heard` / `Telemetry Only` / `Not Heard` / `Crew Active`) are displayed untranslated.

### Summary

- Add the missing AMSAT strings to `values-zh/strings.xml` (nav title, screen title, refresh/retry, legend, header name, load-failed/no-reports messages).
- Localize AMSAT day labels to `M月d日` and the updated timestamp to `yyyy年M月d日 - HH:mm:ss` for Chinese system language only.
- Localize the API status text (`Heard`, `Telemetry Only`, `Not Heard`, `Crew Active`) in the report dialog for Chinese system language only; other locales keep the raw status text and existing English formats.

### Tests

- `./gradlew :core:data:compileDebugKotlin :feature:status:compileDebugKotlin :app:compileDebugKotlin --no-daemon`
- `./gradlew :core:data:testDebugUnitTest --no-daemon`